### PR TITLE
Correct formatting of library.properties category field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0
 author=Yamel Senih
 maintainer=Yamel Senih <info@erpya.com>
 sentence=Allows an Arduino/Genuino write over a SD as file.
-paragraph=category=Device Control
+paragraph=
+category=Device Control
 url=https://github.com/erpcya/Arduino-FileUtil
 architectures=*


### PR DESCRIPTION
Previously, the `category` field was defined on the same line as the `paragraph` field. This caused the `paragraph` field to be defined as "category=Device Control" and for the Arduino IDE to display a warning whenever the library was compiled:
```
WARNING: Category '' in library Arduino-FileUtil is not valid. Setting to 'Uncategorized'
```